### PR TITLE
The bin/ path prefix is assumed by the executables. Removing...

### DIFF
--- a/redmon.gemspec
+++ b/redmon.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = ["bin/redmon"]
+  s.executables   = ["redmon"]
   s.require_paths = ["lib"]
 
   s.add_dependency "bson_ext", ">= 1.4.0"


### PR DESCRIPTION
Had to remove the bin/ to have it build a gem. Error pasted below:

Error:

```
ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
        ["bin/bin/redmon"] are not files
```

Info:

```
[p:redmon@master]:$ ruby -v
ruby 1.9.2p290 (2011-07-09 revision 32553) [i686-linux]

[p:redmon@master]:$ gem -v
1.8.15
```
