### PR TITLE
Make Redmon a mountable Rack app

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,30 @@ $ ruby load_sim.rb
 
 Open your browser to 0.0.0.0:4567
 
+
+## Using in a Rails application
+
+Add to Gemfile:
+
+    gem 'redmon', require: false
+
+Add to config/routes.rb:
+
+    require 'redmon/app'
+    mount Redmon::App => '/redmon'
+
+You can configure the Redmon using an initializer config/initializers/redmon.rb:
+
+```ruby
+Redmon.configure do |config|
+  config.redis_url = 'redis://127.0.0.1:6379'
+  config.namespace = 'redmon'
+  config.poll_interval = 10
+end
+```
+
+This will mount the Redmon application to the /redmon/ path. The trailing slash is important.
+
 ## License
 
 Copyright (c) 2012 Sean McDaniel

--- a/lib/redmon.rb
+++ b/lib/redmon.rb
@@ -1,3 +1,4 @@
+require 'redmon/config'
 require 'active_support/core_ext'
 require 'eventmachine'
 require 'haml'
@@ -10,16 +11,8 @@ module Redmon
 
   attr_reader :opts
 
-  @opts = {
-    :web_interface => ['0.0.0.0', 4567],
-    :redis_url     => 'redis://127.0.0.1:6379',
-    :namespace     => 'redmon',
-    :worker        => true,
-    :poll_interval => 10
-  }
-
   def run(opts={})
-    @opts.merge! opts
+    @opts = Redmon::Config::DEFAULTS.merge(opts)
     start_em
   rescue Exception => e
     log "!!! Redmon has shit the bed, restarting... #{e.message}"
@@ -55,6 +48,7 @@ module Redmon
     puts "[#{Time.now.strftime('%y-%m-%d %H:%M:%S')}] #{msg}"
   end
 
+  # @deprecated
   def [](option)
     opts[option]
   end

--- a/lib/redmon/app.rb
+++ b/lib/redmon/app.rb
@@ -1,5 +1,12 @@
+require 'redmon/helpers'
+
 module Redmon
   class App < Sinatra::Base
+    use Rack::Static, {
+      urls: [/\.css$/, /\.js$/],
+      root: "#{root}/public",
+      cache_control: 'public, max-age=3600'
+    }
 
     helpers Redmon::Helpers
 

--- a/lib/redmon/config.rb
+++ b/lib/redmon/config.rb
@@ -1,0 +1,26 @@
+module Redmon
+  def self.configure
+    yield config
+  end
+
+  def self.config
+    @config ||= Config.new
+  end
+
+  class Config
+    DEFAULTS = {
+      :web_interface => ['0.0.0.0', 4567],
+      :redis_url     => 'redis://127.0.0.1:6379',
+      :namespace     => 'redmon',
+      :worker        => true,
+      :poll_interval => 10
+    }
+
+    attr_accessor(*DEFAULTS.keys)
+
+    def initialize
+      DEFAULTS.each { |k,v| send("#{k}=", v) }
+    end
+
+  end
+end

--- a/lib/redmon/helpers.rb
+++ b/lib/redmon/helpers.rb
@@ -1,3 +1,5 @@
+require 'redmon/redis'
+
 module Redmon
   module Helpers
     include Redmon::Redis
@@ -7,7 +9,7 @@ module Redmon
     end
 
     def poll_interval
-      Redmon[:poll_interval] * 1000
+      Redmon.config.poll_interval * 1000
     end
 
     def count

--- a/lib/redmon/redis.rb
+++ b/lib/redmon/redis.rb
@@ -1,3 +1,5 @@
+require 'redmon/config'
+
 module Redmon
   module Redis
     extend self
@@ -13,15 +15,15 @@ module Redmon
     ]
 
     def redis
-      @redis ||= ::Redis.connect(:url => Redmon[:redis_url])
+      @redis ||= ::Redis.connect(:url => Redmon.config.redis_url)
     end
 
     def ns
-      Redmon[:namespace]
+      Redmon.config.namespace
     end
 
     def redis_url
-      @redis_url ||= Redmon[:redis_url].gsub(/\w*:\w*@/, '')
+      @redis_url ||= Redmon.config.redis_url.gsub(/\w*:\w*@/, '')
     end
 
     def redis_host

--- a/lib/redmon/worker.rb
+++ b/lib/redmon/worker.rb
@@ -34,7 +34,7 @@ module Redmon
     end
 
     def interval
-      Redmon[:poll_interval]
+      Redmon.config.poll_interval
     end
 
   end

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -4,7 +4,7 @@ describe "Helpers" do
 
   describe "redis" do
     it "should call Redis.connect" do
-      Redis.should_receive(:connect).with({:url => Redmon[:redis_url]})
+      Redis.should_receive(:connect).with({:url => Redmon.config.redis_url})
       Redmon::Redis.redis
     end
   end
@@ -19,19 +19,19 @@ describe "Helpers" do
 
   describe "#ns" do
     it "should return the configured namespace" do
-      Redmon[:namespace].should == Redmon::Redis.ns
+      Redmon.config.namespace.should == Redmon::Redis.ns
     end
   end
 
   describe "#redis_url" do
     it "should return the configured redis url" do
-      Redmon[:redis_url].should == Redmon::Redis.redis_url
+      Redmon.config.redis_url.should == Redmon::Redis.redis_url
     end
   end
 
   describe "#redis_host" do
     it "should return the configured redis host" do
-      Redmon[:redis_url].gsub('redis://', '').should == Redmon::Redis.redis_host
+      Redmon.config.redis_url.gsub('redis://', '').should == Redmon::Redis.redis_host
     end
   end
 

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -55,7 +55,7 @@ describe "worker" do
 
   describe "#interval" do
     it "should return the configured poll interval" do
-      @worker.interval.should == Redmon[:poll_interval]
+      @worker.interval.should == Redmon.config.poll_interval
     end
   end
 


### PR DESCRIPTION
This change allows using Redmon alongside another Rack application, such as Rails.
It required to refactor the config handling.
I also updated the README for the usage examples.
