### PR TITLE
Dont relaunch when recieve a SystemExit.

### DIFF
--- a/lib/redmon.rb
+++ b/lib/redmon.rb
@@ -7,8 +7,10 @@ module Redmon
     config.apply opts
     start_em
   rescue Exception => e
-    log "!!! Redmon has shit the bed, restarting... #{e.message}"
-    sleep(1); run(opts)
+    unless e.is_a?(SystemExit)
+      log "!!! Redmon has shit the bed, restarting... #{e.message}"
+      sleep(1); run(opts)
+    end
   end
 
   def start_em


### PR DESCRIPTION
We encountered some probleme when sending kill signal to a worker.
It trap the Exception and relaunch it again ...

Thanks
