### PR TITLE
Using minutes instead of seconds when formatting times for memory usage chart

### DIFF
--- a/lib/redmon/public/redmon.js
+++ b/lib/redmon/public/redmon.js
@@ -65,7 +65,7 @@ var Redmon = (function() {
   }
 
   function formatTime(time) {
-    return d3.time.format('%H:%S')(new Date(time));
+    return d3.time.format('%H:%M')(new Date(time));
   }
 
   /**


### PR DESCRIPTION
Hey,

  I noticed some inconsistency around the times on the X-axis in the memory usage chart.  I believe this is because the time is being formatted as Hours:Seconds rather than Hours:Minutes.  This patch changes the format.

Dan

![Screen Shot 2013-04-14 at 3 25 15 PM](https://f.cloud.github.com/assets/53167/378683/90e5d892-a553-11e2-82c2-7099bac9facf.png)
