### PR TITLE
Fixed problem with finding page templates (issue #38)

### DIFF
--- a/lib/redmon/app.rb
+++ b/lib/redmon/app.rb
@@ -7,6 +7,9 @@ module Redmon
 
     helpers Redmon::Helpers
 
+    set :root, File.dirname(__FILE__)
+    set :views, Proc.new { File.join(root, "./views") }
+
     use Rack::Static, {
       :urls => [/\.css$/, /\.js$/],
       :root => "#{root}/public",


### PR DESCRIPTION
In older Rails versions (like 3.0.x) Sinatra couldn't find templates without setting path to views.
