### PR TITLE
remove bson_ext. unclear why it would be required.

### DIFF
--- a/redmon.gemspec
+++ b/redmon.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.executables   = ["redmon"]
   s.require_paths = ["lib"]
 
-  s.add_dependency "bson_ext", ">= 1.4.0"
   s.add_dependency "sinatra", ">= 1.2.6"
   s.add_dependency "hiredis", "~> 0.4.0"
   s.add_dependency "redis", ">= 2.2.2"


### PR DESCRIPTION
I looked quickly, and could not figure out why the bson_ext would gem would be required by the application. It is incompatible with our production environment. 
