### PR TITLE
load_sim support for AUTH + minor --help for AUTH + test cleanup

### DIFF
--- a/bin/redmon
+++ b/bin/redmon
@@ -26,7 +26,7 @@ class RedmonCLI
     :short       => '-r URL',
     :long        => '--redis URL',
     :default     => 'redis://127.0.0.1:6379',
-    :description => "The Redis url for monitor (default: redis://127.0.0.1:6379)"
+    :description => "The Redis url for monitor (default: redis://127.0.0.1:6379, note: password is support, ie redis://:password@127.0.0.1:6379)"
 
   option :namespace,
     :short       => '-n NAMESPACE',

--- a/load_sim.rb
+++ b/load_sim.rb
@@ -1,20 +1,39 @@
 $: << ::File.expand_path("../lib/", __FILE__)
 require "rubygems"
 require "bundler/setup"
+require 'mixlib/cli'
 require 'redmon'
 require 'redis'
 
-redis = Redis.connect
+class RedmonLoadSimCLI
+	include Mixlib::CLI
 
-loop do
-  start = rand(100000)
-  multi = rand(5)
-  start.upto(multi * start) do |i|
-    redis.set("key-#{i}", "abcdedghijklmnopqrstuvwxyz")
-  end
+	option :redis_url,
+		:short       => '-r URL',
+		:long        => '--redis URL',
+		:default     => 'redis://127.0.0.1:6379',
+		:description => "The Redis url to load simulated traffic against (default: redis://127.0.0.1:6379, note: password is supported, ie redis://:password@127.0.0.1:6379)"
 
-  start.upto(multi * start) do |i|
-    redis.get("key-#{i}")
-    redis.del("key-#{i}")
-  end
+	def run
+		parse_options
+		
+		redis_options = Redis::Client::DEFAULTS || {}
+		redis_options[:url] = config[:redis_url] if config[:redis_url]
+		redis = Redis.new(redis_options)
+
+		loop do
+			start = rand(100000)
+			multi = rand(5)
+			start.upto(multi * start) do |i|
+				redis.set("key-#{i}", "abcdedghijklmnopqrstuvwxyz")
+			end
+
+			start.upto(multi * start) do |i|
+				redis.get("key-#{i}")
+				redis.del("key-#{i}")
+			end
+		end
+	end
 end
+
+RedmonLoadSimCLI.new.run

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -22,25 +22,26 @@ describe "Helpers" do
 
   describe "#ns" do
     it "should return the configured namespace" do
-      Redmon.config.namespace.should == Redmon::Redis.ns
+      Redmon::Redis.ns.should == Redmon.config.namespace
     end
   end
 
   describe "#redis_url" do
     it "should return the configured redis url" do
-      Redmon.config.redis_url.should == Redmon::Redis.redis_url
+      Redmon::Redis.redis_url.should == Redmon.config.redis_url
     end
   end
 
   describe "#redis_host" do
     it "should return the configured redis host" do
-      Redmon.config.redis_url.gsub('redis://', '').should == Redmon::Redis.redis_host
+      config_uri = URI.parse(Redmon.config.redis_url)
+      Redmon::Redis.redis_host.should == "#{config_uri.host}:#{config_uri.port}"
     end
   end
 
   describe "#unquoted" do
     it "should return the configured redis host" do
-      (%w{string OK} << '(empty list or set)').should == Redmon::Redis.unquoted
+      Redmon::Redis.unquoted.should == (%w{string OK} << '(empty list or set)')
     end
   end
 
@@ -56,33 +57,32 @@ describe "Helpers" do
 
   describe "#empty_result" do
     it "should return the empty list message" do
-      '(empty list or set)'.should == Redmon::Redis.empty_result
+      Redmon::Redis.empty_result.should == '(empty list or set)'
     end
   end
 
   describe "#unknown" do
     it "should return the unknown command message" do
-      "(error) ERR unknown command 'unknown'".should == Redmon::Redis.unknown('unknown')
+      Redmon::Redis.unknown("unknown").should == "(error) ERR unknown command 'unknown'"
     end
   end
 
   describe "#wrong_number_of_arguments_for" do
     it "" do
-      "(error) ERR wrong number of arguments for 'unknown' command".should ==
-        Redmon::Redis.wrong_number_of_arguments_for('unknown')
+      Redmon::Redis.wrong_number_of_arguments_for("unknown").should ==
+        "(error) ERR wrong number of arguments for 'unknown' command"
     end
   end
 
   describe "#connection_refused" do
     it "should return the connection refused message" do
-      "Could not connect to Redis at 127.0.0.1:6379: Connection refused".should ==
-        Redmon::Redis.connection_refused
+      Redmon::Redis.connection_refused.should == "Could not connect to Redis at 127.0.0.1:6379: Connection refused"
     end
   end
 
   describe "#stats_key" do
     it "should return the namespaced scoped stats key" do
-      "redmon:redis:127.0.0.1:6379:stats".should == Redmon::Redis.stats_key
+      Redmon::Redis.stats_key.should == "redmon:redis:127.0.0.1:6379:stats"
     end
   end
 


### PR DESCRIPTION
...or bin/redmon.

add --redis url option for load_sim.rb.
implemented pending worker tests.
reversed ordering of assertions for helpers tests to match rspec actual.should eq(expected) format for proper reporting of failed assertions.
