### PR TITLE
Add option for custom base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,22 +40,23 @@ gem install redmon
 
 ```bash
 $ redmon -h
-Usage: /Users/sean/codez/steelThread/redmon/vendor/ruby/1.9.1/bin/redmon (options)
+Usage: bin/redmon (options)
     -a, --address ADDRESS            The thin bind address for the app (default: 0.0.0.0)
-    -n, --namespace NAMESPACE        The root Redis namespace (default: redmon)
+    -b, --base-path BASE_PATH        The base path to expose the service at (default: /)
     -l, --lifespan MINUTES           Lifespan(in minutes) for polled data (default: 30)
+    -n, --namespace NAMESPACE        The root Redis namespace (default: redmon)
     -i, --interval SECS              Poll interval in secs for the worker (default: 10)
     -p, --port PORT                  The thin bind port for the app (default: 4567)
-    -r, --redis URL                  The Redis url for monitor (default: redis://127.0.0.1:6379)
+    -r, --redis URL                  The Redis url for monitor (default: redis://127.0.0.1:6379, note: password is support, ie redis://:password@127.0.0.1:6379)
     -s, --secure CREDENTIALS         Use basic auth. Colon separated credentials, eg admin:admin.
-        --no-app                     Do not run the web app to present stats
-        --no-worker                  Do not run a worker to collect the stats
+        --no-app                     Do not run the web app to present stats (default: true)
+        --no-worker                  Do not run a worker to collect the stats (default: true)
 
 $ redmon
->> Thin web server (v1.3.1 codename Triple Espresso)
->> Maximum connections set to 1024
->> Listening on 0.0.0.0:4567, CTRL+C to stop
-[12-03-10 15:49:40] listening on http#0.0.0.0:4567
+Thin web server (v1.7.0 codename Dunder Mifflin)
+Maximum connections set to 1024
+Listening on 0.0.0.0:4567, CTRL+C to stop
+[16-08-22 19:36:53] listening on http://0.0.0.0:4567/
 ```
 
 If you want to simulate a weak load on redis

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ $ redmon
 Thin web server (v1.7.0 codename Dunder Mifflin)
 Maximum connections set to 1024
 Listening on 0.0.0.0:4567, CTRL+C to stop
-[16-08-22 19:36:53] listening on http://0.0.0.0:4567/
+[16-08-22 19:36:53] listening on http://0.0.0.0:4567
 ```
 
 If you want to simulate a weak load on redis

--- a/bin/redmon
+++ b/bin/redmon
@@ -22,6 +22,12 @@ class RedmonCLI
     :description => "The thin bind port for the app (default: 4567)",
     :proc        => to_i
 
+  option :base_path,
+    :short       => '-b BASE_PATH',
+    :long        => '--base-path BASE_PATH',
+    :default     => '/',
+    :description => "The base path to expose the service at (default: /)"
+
   option :redis_url,
     :short       => '-r URL',
     :long        => '--redis URL',

--- a/lib/redmon.rb
+++ b/lib/redmon.rb
@@ -27,10 +27,13 @@ module Redmon
 
   def start_app
     require 'thin'
+    base_path = config.base_path
     Thin::Server.start(*config.web_interface) do
-      run Redmon::App.new
+      map base_path do
+        run Redmon::App.new
+      end
     end
-    log "listening on http##{config.web_interface.join(':')}"
+    log "listening on http://#{config.web_interface.join(':')}#{base_path}"
   rescue Exception => e
     log "Can't start Redmon::App. port in use? Error: #{e}"
   end

--- a/lib/redmon.rb
+++ b/lib/redmon.rb
@@ -29,8 +29,9 @@ module Redmon
     require 'thin'
     base_path = config.base_path
     Thin::Server.start(*config.web_interface) do
+      app = Redmon::App.new
       map base_path do
-        run Redmon::App.new
+        run app
       end
     end
     log "listening on http://#{config.web_interface.join(':')}#{base_path}"

--- a/lib/redmon/config.rb
+++ b/lib/redmon/config.rb
@@ -11,7 +11,7 @@ module Redmon
     DEFAULTS = {
       :namespace     => 'redmon',
       :redis_url     => 'redis://127.0.0.1:6379',
-      :base_path     => '/',
+      :base_path     => '',
       :app           => true,
       :worker        => true,
       :web_interface => ['0.0.0.0', 4567],

--- a/lib/redmon/config.rb
+++ b/lib/redmon/config.rb
@@ -11,6 +11,7 @@ module Redmon
     DEFAULTS = {
       :namespace     => 'redmon',
       :redis_url     => 'redis://127.0.0.1:6379',
+      :base_path     => '/',
       :app           => true,
       :worker        => true,
       :web_interface => ['0.0.0.0', 4567],


### PR DESCRIPTION
The purpose of this code is to support https://github.com/steelThread/redmon/issues/78 which needs a way to specify a custom base path when running redmon from within Thin. 

The common use case for this is to serve redmon from behind a frontend web proxy (currently the assets won't load).  This code provides a new command line option that can be used as follows:

```
bin/redmon --base-path /redmon
```

This will run the Thin server and serve the content up at `http://localhost:4567/redmon`.  For those running Docker, this will work very nicely with an Image like: https://hub.docker.com/r/vieux/redmon/

Comments & improvements welcomed!  