### PR TITLE
Move runtime gem dependencies from Gemfile back to gemspec file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,28 +2,8 @@ source "http://rubygems.org"
 
 gemspec
 
-gem "rake"
-
-gem "sinatra", ">= 1.2.6"
-gem "hiredis", "~> 0.4.0"
-gem "redis", ">= 2.2.2"
-gem "eventmachine"
-gem "i18n"
-gem "haml"
-gem "rack"
-gem "thin"
-gem "activesupport", "~> 3.2.0"
-# gem "json", "~> 1.7.7"
-gem "mixlib-cli"
-
-group :development do
-  gem "sinatra-contrib", "~> 1.3.1"
-  gem "rack-test"
-end
-
 group :test do
   gem "coveralls", :require => false
-  gem "rspec", "~> 2.8.0"
 end
 
 platforms :ruby_18 do

--- a/redmon.gemspec
+++ b/redmon.gemspec
@@ -19,4 +19,19 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency 'bundler', '~> 1.3'
+  s.add_development_dependency 'sinatra-contrib', '~> 1.3.1'
+  s.add_development_dependency 'rack-test'
+  s.add_development_dependency 'rspec', '~> 2.8.0'
+  s.add_development_dependency 'rake'
+  
+  s.add_dependency 'sinatra', '>= 1.2.6'
+  s.add_dependency 'hiredis', '~> 0.4.0'
+  s.add_dependency 'redis', '>= 2.2.2'
+  s.add_dependency 'eventmachine'
+  s.add_dependency 'i18n'
+  s.add_dependency 'haml'
+  s.add_dependency 'rack'
+  s.add_dependency 'thin'
+  s.add_dependency 'activesupport', '~> 3.2.0'
+  s.add_dependency 'mixlib-cli'
 end


### PR DESCRIPTION
This undoes partially PR https://github.com/steelThread/redmon/pull/75/commits/5cec1c412f3ee9775430cd0ef09e016a50866459

The reason is that dependencies declared in the Gemfile but not in the gemspec are not visible when including this gem in an app bundle. This means that app startup can fail because a necessary gem for redmon (e.g. haml) is not present in the bundle. The fix is to declare all necessary runtime dependencies in the gemspec, so that any bundle that includes this gem will include its dependencies as well.

Fixes https://github.com/steelThread/redmon/issues/86