### PR TITLE
Removed dependency on activesupport.

### DIFF
--- a/redmon.gemspec
+++ b/redmon.gemspec
@@ -32,6 +32,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'haml'
   s.add_dependency 'rack'
   s.add_dependency 'thin'
-  s.add_dependency 'activesupport', '~> 3.2.0'
   s.add_dependency 'mixlib-cli'
 end

--- a/redmon.gemspec
+++ b/redmon.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'rack'
   s.add_dependency 'thin'
   s.add_dependency 'mixlib-cli'
+  s.add_dependency 'json'
 end


### PR DESCRIPTION
Activesupport gem is not used at all in the code as far as I can tell (it's not required in any ruby file). The dependency is unnecessary. Also having it pinned to version 3.x, which is ancient, makes this gem incompatible with Rails 4 and 5 (and Rails 3 is ancient as well).

Fixes https://github.com/steelThread/redmon/issues/88
