### PR TITLE
Use updated way to connect with Redis

### DIFF
--- a/lib/redmon/redis.rb
+++ b/lib/redmon/redis.rb
@@ -15,7 +15,7 @@ module Redmon
     ]
 
     def redis
-      @redis ||= ::Redis.connect(:url => Redmon.config.redis_url)
+      @redis ||= ::Redis.new(:url => Redmon.config.redis_url)
     end
 
     def ns


### PR DESCRIPTION
In the commit https://github.com/redis/redis-rb/commit/895cc3211e335a8fd9ba9322cd311c09eea9621f the Redis library deprecated the `Redis.connect` that this application depends on. Because the Redis dependency doesn't have the version pinned, using the latest version of this application is broken out of the box.

This merge request helps fix that.