### PR TITLE
Support for redis 4

### DIFF
--- a/lib/redmon/redis.rb
+++ b/lib/redmon/redis.rb
@@ -15,7 +15,7 @@ module Redmon
     ]
 
     def redis
-      @redis ||= ::Redis.connect(:url => Redmon.config.redis_url)
+      @redis ||= ::Redis.new(:url => Redmon.config.redis_url)
     end
 
     def ns

--- a/redmon.gemspec
+++ b/redmon.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{Redis monitor}
   s.description = %q{Redis Admin interface and monitor.}
 
-  s.rubyforge_project = "redmon"
+  #s.rubyforge_project = "redmon"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
Since redis 4 the previously deprecated #connect method has been removed. Redmon should use #new instead.